### PR TITLE
Enhance search speed

### DIFF
--- a/inletModelling.py
+++ b/inletModelling.py
@@ -11,6 +11,7 @@ import numpy as np
 import sys
 import random  # package with random generator
 
+random.seed(37)
 
 print("Starting inlet modelling script.\n")
 
@@ -108,7 +109,8 @@ def bubbleShape(C_ID, C_t, timeInterval, shapeID, mgb, mg_StillRequired):
             return False, 0.0
         # If desired, check that the center point denoted by C_ID and C_t follows a certain set of requirements
         C_checked = True
-        timeLoc = C_time-startTime-int((C_time-startTime)/tunit)*tunit
+        timeLoc = C_time-startTime-int((C_time-startTime)/tunit)*tunit  # how many seconds compared to start t_unit
+        # Checks below prevents intersection with beginning of t_unit domain
         if timeLoc < rg/U:
             C_checked = False
         if timeLoc > (tunit-rg/U):
@@ -124,8 +126,12 @@ def bubbleShape(C_ID, C_t, timeInterval, shapeID, mgb, mg_StillRequired):
         mg_bubbleWall = 0.0
         coordCenter = np.array([C_coord[1] - (U * C_time) * normalInlet[0], C_coord[2] - (U * C_time) * normalInlet[1],
                                 C_coord[3] - (U * C_time) * normalInlet[2]])
-        for i in np.arange(len(coordList)):
-            for j in np.arange(int(tunit/timeStepSize)):
+
+        j_min = int((timeLoc - rg/U)/timeStepSize)
+        j_max = int(math.ceil((timeLoc + rg/U)/timeStepSize)) + 1
+
+        for i in np.arange(len(coordList)):  # could be made more efficient by doing already a 2D search in this list
+            for j in range(j_min, j_max):
                 coordPoint = np.array(
                     [coordList[i, 1] - (U * timeVal[t * int(tunit / timeStepSize) + j]) * normalInlet[0],
                      coordList[i, 2] - (U * timeVal[t * int(tunit / timeStepSize) + j]) * normalInlet[1],
@@ -196,21 +202,21 @@ np.save(casePath+'/inletDefinition-time.npy', timeVal) # List containing the tim
 print("Inlet profile saved in Python (numpy) npy-files. \n")
 
 # Check: convert to file compatible with ParaView to visualize your pre-inlet domain.
-print("Saving inlet profile to CSV-files. ")
-files = [casePath+'/inletDefinition-VOFw.csv', casePath+'/inletDefinition-Ux.csv', casePath+'/inletDefinition-Uy.csv', casePath+'/inletDefinition-Uz.csv']
-toWrite = [VOFwVal[:, :, 0], UVal[:, :, 0], UVal[:, :, 1], UVal[:, :, 2]]
-for fi in np.arange(len(files)):
-    f = open(files[fi], 'w')
-    f.write('x coord,y coord,z coord,value \n')
-    for i in np.arange(len(coordList[:, 0])):
-        for j in np.arange(len(timeVal)):
-            coordPoint = np.array([coordList[i, 1] - (U * timeVal[j]) * normalInlet[0],
-                                   coordList[i, 2] - (U * timeVal[j]) * normalInlet[1],
-                                   coordList[i, 3] - (U * timeVal[j]) * normalInlet[2]])
-            f.write(str(coordPoint[0]) + ',' + str(coordPoint[1]) + ',' + str(coordPoint[2]) + ',' + str(
-                toWrite[fi][i, j]) + '\n')
-    f.close()
-print("Inlet profile saved to CSV-files. ")
-
+# print("Saving inlet profile to CSV-files. ")
+# files = [casePath+'/inletDefinition-VOFw.csv', casePath+'/inletDefinition-Ux.csv', casePath+'/inletDefinition-Uy.csv', casePath+'/inletDefinition-Uz.csv']
+# toWrite = [VOFwVal[:, :, 0], UVal[:, :, 0], UVal[:, :, 1], UVal[:, :, 2]]
+# for fi in np.arange(len(files)):
+#     f = open(files[fi], 'w')
+#     f.write('x coord,y coord,z coord,value \n')
+#     for i in np.arange(len(coordList[:, 0])):
+#         for j in np.arange(len(timeVal)):
+#             coordPoint = np.array([coordList[i, 1] - (U * timeVal[j]) * normalInlet[0],
+#                                    coordList[i, 2] - (U * timeVal[j]) * normalInlet[1],
+#                                    coordList[i, 3] - (U * timeVal[j]) * normalInlet[2]])
+#             f.write(str(coordPoint[0]) + ',' + str(coordPoint[1]) + ',' + str(coordPoint[2]) + ',' + str(
+#                 toWrite[fi][i, j]) + '\n')
+#     f.close()
+# print("Inlet profile saved to CSV-files. ")
+#
 
 print("Script 'inletModelling' completed. \n")

--- a/inletModelling.py
+++ b/inletModelling.py
@@ -127,10 +127,14 @@ def bubbleShape(C_ID, C_t, timeInterval, shapeID, mgb, mg_StillRequired):
         coordCenter = np.array([C_coord[1] - (U * C_time) * normalInlet[0], C_coord[2] - (U * C_time) * normalInlet[1],
                                 C_coord[3] - (U * C_time) * normalInlet[2]])
 
+        i_mask = np.linalg.norm(coordList[:, 1:4] - C_coord[1:4], axis=1) < rg
+        i_list = i_mask.nonzero()[0]
+
         j_min = int((timeLoc - rg/U)/timeStepSize)
         j_max = int(math.ceil((timeLoc + rg/U)/timeStepSize)) + 1
 
-        for i in np.arange(len(coordList)):  # could be made more efficient by doing already a 2D search in this list
+        # nested loop could maybe be eliminated by vectorization: boolean arithmetic on the matrices
+        for i in i_list:
             for j in range(j_min, j_max):
                 coordPoint = np.array(
                     [coordList[i, 1] - (U * timeVal[t * int(tunit / timeStepSize) + j]) * normalInlet[0],

--- a/inletModelling.py
+++ b/inletModelling.py
@@ -11,8 +11,6 @@ import numpy as np
 import sys
 import random  # package with random generator
 
-random.seed(37)
-
 print("Starting inlet modelling script.\n")
 
 # Read input from bash-script
@@ -206,21 +204,21 @@ np.save(casePath+'/inletDefinition-time.npy', timeVal) # List containing the tim
 print("Inlet profile saved in Python (numpy) npy-files. \n")
 
 # Check: convert to file compatible with ParaView to visualize your pre-inlet domain.
-# print("Saving inlet profile to CSV-files. ")
-# files = [casePath+'/inletDefinition-VOFw.csv', casePath+'/inletDefinition-Ux.csv', casePath+'/inletDefinition-Uy.csv', casePath+'/inletDefinition-Uz.csv']
-# toWrite = [VOFwVal[:, :, 0], UVal[:, :, 0], UVal[:, :, 1], UVal[:, :, 2]]
-# for fi in np.arange(len(files)):
-#     f = open(files[fi], 'w')
-#     f.write('x coord,y coord,z coord,value \n')
-#     for i in np.arange(len(coordList[:, 0])):
-#         for j in np.arange(len(timeVal)):
-#             coordPoint = np.array([coordList[i, 1] - (U * timeVal[j]) * normalInlet[0],
-#                                    coordList[i, 2] - (U * timeVal[j]) * normalInlet[1],
-#                                    coordList[i, 3] - (U * timeVal[j]) * normalInlet[2]])
-#             f.write(str(coordPoint[0]) + ',' + str(coordPoint[1]) + ',' + str(coordPoint[2]) + ',' + str(
-#                 toWrite[fi][i, j]) + '\n')
-#     f.close()
-# print("Inlet profile saved to CSV-files. ")
-#
+print("Saving inlet profile to CSV-files. ")
+files = [casePath+'/inletDefinition-VOFw.csv', casePath+'/inletDefinition-Ux.csv', casePath+'/inletDefinition-Uy.csv', casePath+'/inletDefinition-Uz.csv']
+toWrite = [VOFwVal[:, :, 0], UVal[:, :, 0], UVal[:, :, 1], UVal[:, :, 2]]
+for fi in np.arange(len(files)):
+    f = open(files[fi], 'w')
+    f.write('x coord,y coord,z coord,value \n')
+    for i in np.arange(len(coordList[:, 0])):
+        for j in np.arange(len(timeVal)):
+            coordPoint = np.array([coordList[i, 1] - (U * timeVal[j]) * normalInlet[0],
+                                   coordList[i, 2] - (U * timeVal[j]) * normalInlet[1],
+                                   coordList[i, 3] - (U * timeVal[j]) * normalInlet[2]])
+            f.write(str(coordPoint[0]) + ',' + str(coordPoint[1]) + ',' + str(coordPoint[2]) + ',' + str(
+                toWrite[fi][i, j]) + '\n')
+    f.close()
+print("Inlet profile saved to CSV-files. ")
+
 
 print("Script 'inletModelling' completed. \n")

--- a/read_inlet_fluent.py
+++ b/read_inlet_fluent.py
@@ -25,7 +25,7 @@ with open('read_inlet.log', 'w') as logfile:
                                          processor_count=cores, show_gui=True)
 
         session.scheme_eval.scheme_eval("(enable-dynamic-mesh-node-ids #t)")
-        session.read_case(case_path / case_name)
+        session.tui.file.read_case(str(case_path / case_name))
 
         # Getting the thread id from Fluent similarly as is done in CoCoNuT
         # Could be replaced by using PyFluent SVARS, but does not work yet

--- a/read_inlet_fluent.py
+++ b/read_inlet_fluent.py
@@ -92,7 +92,7 @@ coord_list[:, 4] = np.linalg.norm(faces[:, 3:6], axis=1)  # face areas
 face_ids = faces[:, 6:10]
 
 normal_inlets = faces[:, 3:6] / coord_list[:, 4].reshape(faces_n, 1)  # compute unit normals on each face
-tol = 1e-15
+tol = 1e-14
 if np.all(normal_inlets.std(axis=0) < tol):
     normal_inlet = normal_inlets.mean(axis=0)
 else:


### PR DESCRIPTION
A speedup with a factor of about 20 was realized by shortening the double for-loop. Additional speedup could be realized by going to a fully vectorized solution, but nevertheless a merge is already requested. 

The code was tested by putting `np.random.seed(37)` on top and comparing the performance. The writing of the csv files was disabled for the tests, since this also takes a long time.

Original test:
Between startTime 0.0s and endTime 1.0s, 1 intervals of 1.0s need to be defined.
Time interval 0 has been defined: 0.008268075071262464kg of gas was inserted. (desired: 0.00826875kg).

(...)

real	**360m55.089s**
user	359m9.835s
sys	1m11.044s

Faster code test:
Between startTime 0.0s and endTime 1.0s, 1 intervals of 1.0s need to be defined.
Time interval 0 has been defined: 0.008268075071262464kg of gas was inserted. (desired: 0.00826875kg).

(...)

real	**17m52.483s**
user	16m5.721s
sys	1m7.917s


